### PR TITLE
Add documentation CI job to run doctests and @example blocks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,3 +60,23 @@ jobs:
         env:
           AA228V_PROJECTS_DIR: ${{ runner.temp }}/projects
           AA228V_CI_MODE: "1"
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1.13'
+          include-all-prereleases: true
+      - uses: julia-actions/cache@v2
+      - name: Add SISL Registry
+        run: julia -e 'using Pkg; Pkg.Registry.add(RegistrySpec(url="https://github.com/sisl/Registry"))'
+      - name: Install dependencies
+        run: julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and test documentation
+        run: julia --project=docs docs/make.jl

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,7 +19,6 @@ makedocs(
         "Home" => "index.md",
     ],
     doctest = true,  # Enable doctests
-    warnonly = [:doctest],  # Don't fail on doctest errors, just warn
     plugins = [bib, links]
 )
 


### PR DESCRIPTION
- Add separate 'docs' job that builds documentation in parallel with tests
- Remove :doctest from warnonly so doctest failures actually fail CI
- This ensures docstrings stay up-to-date for use in Pluto notebooks

https://claude.ai/code/session_01NRPyCfvxjYNHRFjhebfACc